### PR TITLE
contentResponseOnWriteEnabled プロパティ追加

### DIFF
--- a/src/main/java/com/kohei3110/javaonazurecosmosdemo/CosmosCRUD/repository/CreateItemRepository.java
+++ b/src/main/java/com/kohei3110/javaonazurecosmosdemo/CosmosCRUD/repository/CreateItemRepository.java
@@ -34,12 +34,14 @@ public class CreateItemRepository {
             this.cosmosClient = new CosmosClientBuilder()
                 .endpoint(System.getenv("COSMOSDB_ENDPOINT"))
                 .key(System.getenv("COSMOSDB_KEY"))
+                .contentResponseOnWriteEnabled(true)
                 .buildClient();
             this.cosmosDatabase = this.cosmosClient.getDatabase(DATABASE_ID);
             this.cosmosContainer = this.cosmosDatabase.getContainer(CONTAINER_ID);
             this.cosmosAsyncClient = new CosmosClientBuilder()
                 .endpoint(System.getenv("COSMOSDB_ENDPOINT"))
                 .key(System.getenv("COSMOSDB_KEY"))
+                .contentResponseOnWriteEnabled(true)
                 .buildAsyncClient();
             this.cosmosAsyncDatabase = this.cosmosAsyncClient.getDatabase(DATABASE_ID);
             this.cosmosAsyncContainer = this.cosmosAsyncDatabase

--- a/src/main/java/com/kohei3110/javaonazurecosmosdemo/CosmosCRUD/repository/DeleteItemRepository.java
+++ b/src/main/java/com/kohei3110/javaonazurecosmosdemo/CosmosCRUD/repository/DeleteItemRepository.java
@@ -32,12 +32,14 @@ public class DeleteItemRepository {
             this.cosmosClient = new CosmosClientBuilder()
                 .endpoint(System.getenv("COSMOSDB_ENDPOINT"))
                 .key(System.getenv("COSMOSDB_KEY"))
+                .contentResponseOnWriteEnabled(true)
                 .buildClient();
             this.cosmosDatabase = this.cosmosClient.getDatabase(DATABASE_ID);
             this.cosmosContainer = this.cosmosDatabase.getContainer(CONTAINER_ID);
             this.cosmosAsyncClient = new CosmosClientBuilder()
                 .endpoint(System.getenv("COSMOSDB_ENDPOINT"))
                 .key(System.getenv("COSMOSDB_KEY"))
+                .contentResponseOnWriteEnabled(true)
                 .buildAsyncClient();
             this.cosmosAsyncDatabase = this.cosmosAsyncClient.getDatabase(DATABASE_ID);
             this.cosmosAsyncContainer = this.cosmosAsyncDatabase

--- a/src/main/java/com/kohei3110/javaonazurecosmosdemo/CosmosCRUD/repository/UpdateItemRepository.java
+++ b/src/main/java/com/kohei3110/javaonazurecosmosdemo/CosmosCRUD/repository/UpdateItemRepository.java
@@ -34,12 +34,14 @@ public class UpdateItemRepository {
             this.cosmosClient = new CosmosClientBuilder()
                 .endpoint(System.getenv("COSMOSDB_ENDPOINT"))
                 .key(System.getenv("COSMOSDB_KEY"))
+                .contentResponseOnWriteEnabled(true)
                 .buildClient();
             this.cosmosDatabase = this.cosmosClient.getDatabase(DATABASE_ID);
             this.cosmosContainer = this.cosmosDatabase.getContainer(CONTAINER_ID);
             this.cosmosAsyncClient = new CosmosClientBuilder()
                 .endpoint(System.getenv("COSMOSDB_ENDPOINT"))
                 .key(System.getenv("COSMOSDB_KEY"))
+                .contentResponseOnWriteEnabled(true)
                 .buildAsyncClient();
             this.cosmosAsyncDatabase = this.cosmosAsyncClient.getDatabase(DATABASE_ID);
             this.cosmosAsyncContainer = this.cosmosAsyncDatabase


### PR DESCRIPTION
## 対応範囲

- レスポンスに item を含めるよう修正
  - `contentResponseOnWriteEnabled` を `true` に修正

## 参考

- [CosmosClientBuilder.contentResponseOnWriteEnabled(boolean contentResponseOnWriteEnabled) Method](https://docs.microsoft.com/en-us/java/api/com.azure.cosmos.cosmosclientbuilder.contentresponseonwriteenabled?view=azure-java-stable)